### PR TITLE
Fix issues in CustomHttpClient sample implementation

### DIFF
--- a/CustomHttpClient.java
+++ b/CustomHttpClient.java
@@ -110,7 +110,7 @@ public class CustomHttpClient implements UsabillaHttpClient {
                             body = responseBody.string();
                         }
                     } catch (IOException e1) {
-                        Timber.d("Custom http client response failed to read body with exception: %s", e.getLocalizedMessage());
+                        Timber.d("Custom http client response failed to read body with exception: %s", e1.getLocalizedMessage());
                     }
                     error = response.message();
                     headers = new HashMap<>();

--- a/CustomHttpClient.java
+++ b/CustomHttpClient.java
@@ -110,7 +110,7 @@ public class CustomHttpClient implements UsabillaHttpClient {
                             body = responseBody.string();
                         }
                     } catch (IOException e1) {
-                        Timber.d("Custom http client response failed to read body with exception: %s", e1.getLocalizedMessage());
+                        Log.i("CustomHttpClient", "Custom http client response failed to read body with exception: " + e1.getLocalizedMessage());
                     }
                     error = response.message();
                     headers = new HashMap<>();

--- a/CustomHttpClient.java
+++ b/CustomHttpClient.java
@@ -13,11 +13,7 @@
 public class CustomHttpClient implements UsabillaHttpClient {
 
     private OkHttpClient client = new OkHttpClient();
-    private WeakReference<Activity> activityReference;
-
-    CustomHttpClient(Activity activity) {
-        activityReference = new WeakReference(activity);
-    }
+    private Handler mainHandler = new Handler(Looper.getMainLooper());
 
     @Override
     public void execute(@NotNull UsabillaHttpRequest usabillaRequest, @NotNull UsabillaHttpListener listener) {
@@ -68,7 +64,7 @@ public class CustomHttpClient implements UsabillaHttpClient {
         @Override
         public void onFailure(Call call, final IOException e) {
             CustomUsabillaHttpResponse customResponse = new CustomUsabillaHttpResponse(e);
-            activityReference.get().runOnUiThread(new Runnable() {
+            mainHandler.post(new Runnable() {
                 @Override
                 public void run() {
                     listener.onFailure(customResponse);
@@ -81,7 +77,7 @@ public class CustomHttpClient implements UsabillaHttpClient {
         public void onResponse(Call call, final Response response) {
             CustomUsabillaHttpResponse customResponse = new CustomUsabillaHttpResponse(response);
             boolean successful = response.isSuccessful();
-            activityReference.get().runOnUiThread(new Runnable() {
+            mainHandler.post(new Runnable() {
                 @Override
                 public void run() {
                     if (successful) {


### PR DESCRIPTION
I run into NetworkOnMainThread exceptions on Kitkat devices because `returnValue = body.string()` got called on the ui thread. Adding an wrapper class to create the UsabillaHttpResponse fixed this issue.

I also don't see the need to pass in an activity since we can get the ui thread from the os looper which allows easier instantiation.

Maybe you can take a look at my changes and improve your sample implementation.