### PR TITLE
Release v7.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ### Changelog:
+## v7.6.2
+#### Fix
+- Error occurring while showing a standard event when the device is offline
+- Error occurring when the logo is clicked
+- Error message not dismissed when the value of a component changed.
 ## v7.6.1
 #### Fix
 - Text issues with Chinese

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The following functionalities will only be available on phones running Android A
 Grab the latest version using
 
 ```
-implementation 'com.usabilla.sdk:ubform:7.6.1'
+implementation 'com.usabilla.sdk:ubform:7.6.2'
 ```
 
 If you have obfuscation enabled (ProGuard/R8) and you use a version of our SDK <= 6.4.0 you need to add this line to your obfuscation configuration
@@ -306,7 +306,7 @@ The data collected content is as follows:
   "reachability": "WiFi",
   "rooted": false,
   "screenSize": "1440x2392",
-  "sdkVersion": "7.6.1",
+  "sdkVersion": "7.6.2",
   "system": "android",
   "totalMemory": "1530604",
   "totalSpace": "793488",


### PR DESCRIPTION
## v7.6.2
#### Fix
- Error occurring while showing a standard event when the device is offline
- Error occurring when the logo is clicked
- Error message not dismissed when the value of a component changed.